### PR TITLE
Removes redundant closing input tags and improves .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,30 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+### OSX ###
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk

--- a/examples/todo/index.html
+++ b/examples/todo/index.html
@@ -28,11 +28,11 @@
   <template data-name='todo'>
     <div class="todos">
       <div class='todo-main'>
-        <input data-field='checked' type="checkbox" class="check"></input>
+        <input data-field='checked' type="checkbox" class="check" />
         <label data-field='todo' class="todo-text"></label>
         <button class="delete"></button>
       </div>
-      <input type='text' class='edit-todo' placeholder='' /></input>
+      <input type='text' class='edit-todo' placeholder='' />
     </div>
   </template>
 


### PR DESCRIPTION
The input tags in index.html of todo example had redundant closing tags. Removed it and also used the same inline closing for all input tags.

Also updated the gitignore to ignore files from OSX.
